### PR TITLE
jsTest creates infinite amount of tests

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,78 @@
+name: master
+
+on: pull_request
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
+      - name: Run tests
+        run: ./gradlew check
+
+      - name: Bundle the build report
+        if: failure()
+        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
+
+      - name: Upload the build report
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: error-report
+          path: build-reports.zip
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run macos tests
+        run: ./gradlew macosX64Test
+
+      - name: Bundle the build report
+        if: failure()
+        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
+
+      - name: Upload the build report
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: error-report
+          path: build-reports.zip
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run tests
+        run: ./gradlew mingwX64Test
+
+      - name: Bundle the build report
+        if: failure()
+        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
+
+      - name: Upload the build report
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: error-report
+          path: build-reports.zip
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/src/commonTest/kotlin/io/kotest/examples/mpp/TestOne.kt
+++ b/src/commonTest/kotlin/io/kotest/examples/mpp/TestOne.kt
@@ -1,0 +1,86 @@
+package io.kotest.examples.mpp
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+
+class TestOne : StringSpec({
+   "This test is skipped" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped2" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped3" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped4" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped5" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped6" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped7" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped8" {
+      delay(10)
+      true shouldBe true
+   }
+   "This test is skipped9" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped10" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped11" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped12" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped13" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped14" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped15" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped16" {
+      delay(10)
+      true shouldBe true
+   }
+})

--- a/src/commonTest/kotlin/io/kotest/examples/mpp/TestThree.kt
+++ b/src/commonTest/kotlin/io/kotest/examples/mpp/TestThree.kt
@@ -1,0 +1,86 @@
+package io.kotest.examples.mpp
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+
+class TestThree : StringSpec({
+   "This test is skipped" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped2" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped3" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped4" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped5" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped6" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped7" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped8" {
+      delay(10)
+      true shouldBe true
+   }
+   "This test is skipped9" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped10" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped11" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped12" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped13" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped14" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped15" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped16" {
+      delay(10)
+      true shouldBe true
+   }
+})

--- a/src/commonTest/kotlin/io/kotest/examples/mpp/TestTwo.kt
+++ b/src/commonTest/kotlin/io/kotest/examples/mpp/TestTwo.kt
@@ -1,0 +1,86 @@
+package io.kotest.examples.mpp
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+
+class TestTwo : StringSpec({
+   "This test is skipped" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped2" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped3" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped4" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped5" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped6" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped7" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped8" {
+      delay(10)
+      true shouldBe true
+   }
+   "This test is skipped9" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped10" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped11" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped12" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped13" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped14" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped15" {
+      delay(10)
+      true shouldBe true
+   }
+
+   "This test is skipped16" {
+      delay(10)
+      true shouldBe true
+   }
+})


### PR DESCRIPTION
When adding the new Kotest to Arrow we saw that `jsTest` was creating an infinite amount of tests, and eventually the browser or node crashes and this made Gradle hang forever.

After a long time of debugging I figured out this seemed to happen whenever I added 3 or more test files, regardless of the content of the tests themselves.
I'm not sure if it's about a certain amount of tests or specs that causes the issue.