### PR TITLE
Add missing Kotest multiplatform Gradle plugin to build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
    java
    id("java-library")
    alias(libs.plugins.kotlin.multiplatform)
+   alias(libs.plugins.kotest.multiplatform)
 }
 
 allprojects {


### PR DESCRIPTION
From a [conversation on kotlinlang Slack](https://kotlinlang.slack.com/archives/CT0G9SD7Z/p1694621890669949):

> When cloning the project and running ./gradlew check , only the JVM tests are executed. I was expecting to see the JS tests and the MacOS tests as well.