### PR TITLE
Wire kotest-amper into CI and bump Kotlin/Kotest

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,19 +13,20 @@ on:
 
 # This will prevent multiple parallel runs and will cancel queued runs except the latest one.
 concurrency:
-   group: 'master-ci'
-   cancel-in-progress: false
+  group: 'master-ci'
+  cancel-in-progress: false
 
 permissions:
-   contents: read
+  contents: read
 jobs:
   linux:
     strategy:
       fail-fast: false
       matrix:
-        project: 
+        project:
           - kotest-allure
           - kotest-android
+          - kotest-amper
           - kotest-gradle-retry
           - kotest-javascript
           - kotest-jvm
@@ -36,6 +37,12 @@ jobs:
           - kotest-spring-webflux
           - kotest-wasm
           - kotest-multi-module
+        include:
+          - command: ./gradlew check
+          - command: mvn -B test #override to use maven for the maven example
+            project: kotest-maven
+          - command: amper test #override to use amper for the amper example
+            project: kotest-amper
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -50,14 +57,8 @@ jobs:
           java-version-file: .github/.java-version
 
       - name: Run tests
-        if: matrix.project != 'kotest-maven' # the maven example doesn't use gradle of course
         working-directory: ./${{ matrix.project }}
-        run: ./gradlew check
-
-      - name: Run tests
-        if: matrix.project == 'kotest-maven' # the maven example doesn't use gradle of course
-        working-directory: ./${{ matrix.project }}
-        run: mvn -B test
+        run: ${{ matrix.command }}
 
       - name: Bundle the build report
         if: failure()
@@ -75,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project:       
+        project:
           - kotest-multiplatform
           - kotest-native
     steps:
@@ -87,8 +88,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-           distribution: 'temurin'
-           java-version-file: .github/.java-version
+          distribution: 'temurin'
+          java-version-file: .github/.java-version
 
       - name: Run tests
         working-directory: ./${{ matrix.project }}
@@ -122,8 +123,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-           distribution: 'temurin'
-           java-version-file: .github/.java-version
+          distribution: 'temurin'
+          java-version-file: .github/.java-version
 
       - name: Run tests
         working-directory: ./${{ matrix.project }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,7 +41,7 @@ jobs:
           - command: ./gradlew check
           - command: mvn -B test #override to use maven for the maven example
             project: kotest-maven
-          - command: amper test #override to use amper for the amper example
+          - command: ./amper test #override to use the amper wrapper for the amper example
             project: kotest-amper
     runs-on: ubuntu-latest
     steps:

--- a/kotest-amper/.editorconfig
+++ b/kotest-amper/.editorconfig
@@ -8,3 +8,6 @@ max_line_length = 120
 
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yaml]
+indent_size = 2

--- a/kotest-amper/module.yaml
+++ b/kotest-amper/module.yaml
@@ -4,11 +4,11 @@ settings:
   kotlin:
     version: 2.3.20
   jvm:
-    release: 17
+    release: 21
   junit: junit-5
 
 test-dependencies:
-  - io.kotest:kotest-runner-junit5:6.1.10
-  - io.kotest:kotest-assertions-core:6.1.10
-  - io.kotest:kotest-framework-engine:6.1.10
+  - io.kotest:kotest-runner-junit5:6.1.11
+  - io.kotest:kotest-assertions-core:6.1.11
+  - io.kotest:kotest-framework-engine:6.1.11
   - org.junit.jupiter:junit-jupiter:6.0.3

--- a/kotest-amper/test/io/kotest/examples/jvm/DurationTest.kt
+++ b/kotest-amper/test/io/kotest/examples/jvm/DurationTest.kt
@@ -2,15 +2,16 @@ package io.kotest.examples.jvm
 
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 class DurationTest : FunSpec({
 
    context("test suite") {
-      delay(100) // look ma, I can use coroutines here!
+      delay(100.milliseconds) // look ma, I can use coroutines here!
       context("nested test suite") {
-         delay(200) // look ma, I can use coroutines here!
+         delay(200.milliseconds) // look ma, I can use coroutines here!
          test("leaf test") {
-            delay(300) // look ma, I can use coroutines here!
+            delay(300.milliseconds) // look ma, I can use coroutines here!
          }
       }
    }

--- a/kotest-amper/test/io/kotest/examples/jvm/ProjectConfig.kt
+++ b/kotest-amper/test/io/kotest/examples/jvm/ProjectConfig.kt
@@ -1,21 +1,12 @@
 package io.kotest.examples.jvm
 
 import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.core.listeners.AfterTestListener
-import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 
 /**
- * An example Kotest extension that prints the duration of each test.
- */
-object TimerListener : AfterTestListener {
-   override suspend fun afterAny(testCase: TestCase, result: TestResult) =
-      println("- ${testCase.name.name} ${result.duration}")
-}
-
-/**
- * Example of product config, registering a Kotest extension.
+ * Example of product config.
  */
 object ProjectConfig : AbstractProjectConfig() {
-   override val extensions = listOf(TimerListener)
+   override suspend fun beforeProject() {
+      println("Kotest Amper is starting")
+   }
 }

--- a/kotest-android/app/src/androidTest/kotlin/io/kotest/examples/android/ComposeWithKotest.kt
+++ b/kotest-android/app/src/androidTest/kotlin/io/kotest/examples/android/ComposeWithKotest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(KotestTestRunner::class)
-class ComposeWithKotest : FreeSpec() {
+open class ComposeWithKotest : FreeSpec() {
 
    @get:Rule
    val composeTestRule: ComposeContentTestRule = createComposeRule()


### PR DESCRIPTION
## Summary
- Add the \`kotest-amper\` example to the linux CI matrix, and let the matrix specify per-project commands so amper uses \`amper test\` and maven uses \`mvn -B test\`.
- Upgrade kotest-amper to Kotlin 2.3.20, Kotest 6.1.11, and JVM release 21; tidy up \`ProjectConfig\` and \`DurationTest\`.

## Test plan
- [ ] CI: \`linux (kotest-amper)\` job passes with \`amper test\`
- [ ] CI: existing \`./gradlew check\` jobs (multiplatform, jvm, etc.) still pass under the new include-based matrix